### PR TITLE
Common 기능 추가

### DIFF
--- a/common/src/main/java/com/farm2pot/common/config/WebMvcConfig.java
+++ b/common/src/main/java/com/farm2pot/common/config/WebMvcConfig.java
@@ -1,0 +1,22 @@
+package com.farm2pot.common.config;
+
+import com.farm2pot.common.resolver.PageRequestArgumentResolver;
+import com.farm2pot.common.resolver.SortRequestArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+/**
+ * Spring Web MVC 설정
+ */
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new PageRequestArgumentResolver());
+        resolvers.add(new SortRequestArgumentResolver());
+    }
+}

--- a/common/src/main/java/com/farm2pot/common/exception/BaseErrorCode.java
+++ b/common/src/main/java/com/farm2pot/common/exception/BaseErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
  * description    :
  */
 public interface BaseErrorCode {
-    HttpStatus getStatus();
+    HttpStatus getHttpStatus();
     String getCode();
     String getMessage();
 }

--- a/common/src/main/java/com/farm2pot/common/exception/BaseException.java
+++ b/common/src/main/java/com/farm2pot/common/exception/BaseException.java
@@ -26,7 +26,7 @@ public class BaseException extends RuntimeException {
     }
 
     public HttpStatus getStatus() {
-        return errorCode.getStatus();
+        return errorCode.getHttpStatus();
     }
 
     public String getCode() {

--- a/common/src/main/java/com/farm2pot/common/http/request/CustomPageRequest.java
+++ b/common/src/main/java/com/farm2pot/common/http/request/CustomPageRequest.java
@@ -1,0 +1,45 @@
+package com.farm2pot.common.http.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ArrayUtils;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+
+/**
+ * 클라이언트의 Page parameter => ArgumentResolver 용도
+ */
+@Data
+@AllArgsConstructor(staticName = "of")
+@NoArgsConstructor
+public class CustomPageRequest {
+    private int page;
+    private int pageSize;
+    private String[] sort;
+
+    // jpa 페이징에 사용되는 페이징객체 반환 (pageNumber 는 0부터 시작해야 함)
+    public PageRequest getPageable() {
+        if (ArrayUtils.isEmpty(sort)) {
+            return PageRequest.of(page - 1, pageSize);
+        } else {
+            Sort sortObj = Sort.unsorted();
+
+            try {
+                sortObj = Sort.by(Arrays.stream(sort).map(sortItem -> {
+                    String[] arr = sortItem.split(",");
+                    if (Sort.Direction.ASC.toString().equalsIgnoreCase(arr[1])) {
+                        return Sort.Order.asc(arr[0]);
+                    } else {
+                        return Sort.Order.desc(arr[0]);
+                    }
+                }).toList());
+            } catch (Exception e) {
+            }
+
+            return PageRequest.of(page - 1, pageSize, sortObj);
+        }
+    }
+}

--- a/common/src/main/java/com/farm2pot/common/http/request/CustomSortRequest.java
+++ b/common/src/main/java/com/farm2pot/common/http/request/CustomSortRequest.java
@@ -1,0 +1,33 @@
+package com.farm2pot.common.http.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+import java.util.Arrays;
+
+/**
+ * 클라이언트의 Sort parameter => ArgumentResolver 용도
+ */
+@Data
+@AllArgsConstructor(staticName = "of")
+@NoArgsConstructor
+public class CustomSortRequest {
+    private String[] sort;
+
+    public Sort getSort() {
+        try {
+            return Sort.by(Arrays.stream(sort).map(sortItem -> {
+                String[] arr = sortItem.split(",");
+                if (Sort.Direction.ASC.toString().equalsIgnoreCase(arr[1])) {
+                    return Sort.Order.asc(arr[0]);
+                } else {
+                    return Sort.Order.desc(arr[0]);
+                }
+            }).toList());
+        } catch (Exception e) {
+            return Sort.unsorted();
+        }
+    }
+}

--- a/common/src/main/java/com/farm2pot/common/http/response/ApiResponse.java
+++ b/common/src/main/java/com/farm2pot/common/http/response/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.farm2pot.common.http.response;
 
+import com.farm2pot.common.exception.BaseErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
@@ -34,7 +35,7 @@ public record ApiResponse<T>(
     }
 
     // 성공 응답 (ResponseCode 기반)
-    public static <T> ApiResponse<T> of(T data, ApiResponseCode responseCode) {
+    public static <T> ApiResponse<T> of(T data, BaseErrorCode responseCode) {
         return ApiResponse.<T>builder()
                 .data(data)
                 .responseCode(responseCode.getCode())
@@ -43,7 +44,7 @@ public record ApiResponse<T>(
     }
 
     // 성공 응답 (ResponseCode + 커스텀 메시지)
-    public static <T> ApiResponse<T> of(T data, ApiResponseCode responseCode, String message) {
+    public static <T> ApiResponse<T> of(T data, BaseErrorCode responseCode, String message) {
         return ApiResponse.<T>builder()
                 .data(data)
                 .responseCode(responseCode.getCode())
@@ -51,29 +52,29 @@ public record ApiResponse<T>(
                 .build();
     }
 
-    // 에러 응답 (ResponseCode 기반)
-    public static <T> ApiResponse<T> error(ApiResponseCode responseCode) {
+    // 에러 응답 (BaseErrorCode 기반)
+    public static <T> ApiResponse<T> error(BaseErrorCode errorCode) {
         return ApiResponse.<T>builder()
                 .data(null)
-                .responseCode(responseCode.getCode())
-                .responseMessage(responseCode.getMessage())
+                .responseCode(errorCode.getCode())
+                .responseMessage(errorCode.getMessage())
                 .build();
     }
 
-    // 에러 응답 (ResponseCode + 커스텀 메시지)
-    public static <T> ApiResponse<T> error(ApiResponseCode responseCode, String message) {
+    // 에러 응답 (BaseErrorCode + 커스텀 메시지)
+    public static <T> ApiResponse<T> error(BaseErrorCode errorCode, String message) {
         return ApiResponse.<T>builder()
                 .data(null)
-                .responseCode(responseCode.getCode())
+                .responseCode(errorCode.getCode())
                 .responseMessage(message)
                 .build();
     }
 
-    // 에러 응답 (ResponseCode + 메시지 + 데이터)
-    public static <T> ApiResponse<T> error(ApiResponseCode responseCode, String message, T data) {
+    // 에러 응답 (BaseErrorCode + 메시지 + 데이터)
+    public static <T> ApiResponse<T> error(BaseErrorCode errorCode, String message, T data) {
         return ApiResponse.<T>builder()
                 .data(data)
-                .responseCode(responseCode.getCode())
+                .responseCode(errorCode.getCode())
                 .responseMessage(message)
                 .build();
     }

--- a/common/src/main/java/com/farm2pot/common/http/response/ApiResponseCode.java
+++ b/common/src/main/java/com/farm2pot/common/http/response/ApiResponseCode.java
@@ -1,5 +1,6 @@
 package com.farm2pot.common.http.response;
 
+import com.farm2pot.common.exception.BaseErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -9,7 +10,7 @@ import org.springframework.http.HttpStatus;
  */
 @Getter
 @RequiredArgsConstructor
-public enum ApiResponseCode {
+public enum ApiResponseCode implements BaseErrorCode {
 
     // 성공 응답
     SUCCESS(HttpStatus.OK, "SUCCESS", "성공"),
@@ -35,8 +36,4 @@ public enum ApiResponseCode {
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;
-
-    public int getStatusValue() {
-        return httpStatus.value();
-    }
 }

--- a/common/src/main/java/com/farm2pot/common/jpa/BaseEntity.java
+++ b/common/src/main/java/com/farm2pot/common/jpa/BaseEntity.java
@@ -1,0 +1,30 @@
+package com.farm2pot.common.jpa;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedBy
+    private String createUserId;
+
+    @CreatedDate
+    private LocalDateTime createAt;
+
+    @LastModifiedBy
+    private String updateUserId;
+
+    @LastModifiedDate
+    private LocalDateTime updateAt;
+}

--- a/common/src/main/java/com/farm2pot/common/resolver/PageRequestArgumentResolver.java
+++ b/common/src/main/java/com/farm2pot/common/resolver/PageRequestArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.farm2pot.common.resolver;
+
+import com.farm2pot.common.http.request.CustomPageRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * CustomPageRequest를 위한 ArgumentResolver
+ * 클라이언트의 page, pageSize, sort 파라미터를 자동으로 CustomPageRequest로 변환
+ */
+public class PageRequestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PAGE_SIZE = 20;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(CustomPageRequest.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String pageParam = webRequest.getParameter("page");
+        String pageSizeParam = webRequest.getParameter("pageSize");
+
+        int page = pageParam != null ? Integer.parseInt(pageParam) : DEFAULT_PAGE;
+        int pageSize = pageSizeParam != null ? Integer.parseInt(pageSizeParam) : DEFAULT_PAGE_SIZE;
+
+        // sort 파라미터 (다중 값 지원)
+        String[] sort = webRequest.getParameterValues("sort");
+
+        return CustomPageRequest.of(page, pageSize, sort);
+    }
+}

--- a/common/src/main/java/com/farm2pot/common/resolver/SortRequestArgumentResolver.java
+++ b/common/src/main/java/com/farm2pot/common/resolver/SortRequestArgumentResolver.java
@@ -1,0 +1,28 @@
+package com.farm2pot.common.resolver;
+
+import com.farm2pot.common.http.request.CustomSortRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * CustomSortRequest를 위한 ArgumentResolver
+ * 클라이언트의 sort 파라미터를 자동으로 CustomSortRequest로 변환
+ */
+public class SortRequestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(CustomSortRequest.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        // sort 파라미터 (다중 값 지원)
+        String[] sort = webRequest.getParameterValues("sort");
+
+        return CustomSortRequest.of(sort);
+    }
+}


### PR DESCRIPTION
### 1. 응답에서 예외는 기존 예외코드 사용하도록 변경

### 2. 공통 Entity 공통 클래스 추가

### 3. PageRequestArgumentResolver  / SortRequestArgumentResolver
- page, pageSize, sort 파라미터를 자동으로 CustomRequest로 변환
- 기본값: page=1, pageSize=20
- 다중 정렬 지원 (sort=name,asc&sort=price,desc)
- WebMvcConfig : 두 Resolver를 Spring MVC에 등록
> API 호출 예시
> GET `/api/admin/products?page=1&pageSize=10&sort=createAt,desc&sort=name,asc`

    - page는 1부터 시작 (내부적으로 0부터 시작하도록 자동 변환)
    - 다중 정렬 지원 (sort 파라미터를 여러 개 전달 가능)
    - 기본값 자동 설정 (page=1, pageSize=20)
    - Controller는 간단하게 CustomPageRequest만 받으면 됨