### PR TITLE
refactor: gateway의 WebFlux와 MVC(Spring Web) 충돌 문제 수정

### DIFF
--- a/apps/gateway/src/main/java/com/farm2pot/common/exception/GatewayErrorCode.java
+++ b/apps/gateway/src/main/java/com/farm2pot/common/exception/GatewayErrorCode.java
@@ -24,7 +24,7 @@ public enum GatewayErrorCode implements BaseErrorCode {
     // 기타 공통 오류
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GATE_999", "서버 내부 오류가 발생했습니다.");
 
-    private final HttpStatus status;
+    private final HttpStatus httpStatus;
     private final String code;
     private final String message;
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,7 +7,10 @@ plugins {
 dependencies {
     // common이 필요한 최소한의 의존성만
     api 'org.springframework.boot:spring-boot-starter'
-    api 'org.springframework.boot:spring-boot-starter-web'
+
+    // MVC 관련 의존성 - 컴파일 시에만 필요, 런타임은 각 모듈에서 제공
+    // Gateway(WebFlux)에는 포함되지 않고, Admin/User 등 MVC 모듈에서만 사용
+    compileOnly 'org.springframework.boot:spring-boot-starter-web'
 
     // MapStruct
     api "org.mapstruct:mapstruct:${mapstructVersion}"

--- a/common/src/main/java/com/farm2pot/common/http/advice/ApiControllerAdvice.java
+++ b/common/src/main/java/com/farm2pot/common/http/advice/ApiControllerAdvice.java
@@ -4,6 +4,9 @@ import com.farm2pot.common.exception.BaseException;
 import com.farm2pot.common.http.response.ApiResponse;
 import com.farm2pot.common.http.response.ApiResponseCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -24,6 +27,9 @@ import java.util.Map;
  */
 @Slf4j
 @RestControllerAdvice
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnClass(NoHandlerFoundException.class)
+@ConditionalOnProperty(name = "common.response.wrap.enabled", havingValue = "true", matchIfMissing = true)
 public class ApiControllerAdvice {
 
     /**

--- a/common/src/main/java/com/farm2pot/common/http/advice/ApiResponseBodyAdvice.java
+++ b/common/src/main/java/com/farm2pot/common/http/advice/ApiResponseBodyAdvice.java
@@ -1,6 +1,9 @@
-package com.farm2pot.common.http.advice;
+﻿package com.farm2pot.common.http.advice;
 
 import com.farm2pot.common.http.response.ApiResponse;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -14,6 +17,9 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
  * Controller에서 DTO만 반환하면 자동으로 공통 응답 형태로 변환
  */
 @RestControllerAdvice(basePackages = "com.farm2pot")
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnClass(org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice.class)
+@ConditionalOnProperty(name = "common.response.wrap.enabled", havingValue = "true", matchIfMissing = true)
 public class ApiResponseBodyAdvice implements ResponseBodyAdvice<Object> {
 
     @Override

--- a/config/gateway/application-dev.yml
+++ b/config/gateway/application-dev.yml
@@ -52,3 +52,9 @@ logging:
     org.springframework.boot.web.embedded.netty: DEBUG
 
 
+
+common:
+  response:
+    wrap:
+      enabled: false
+

--- a/config/gateway/application-prod.yml
+++ b/config/gateway/application-prod.yml
@@ -50,3 +50,9 @@ logging:
     com.farm2pot: ${LOGGING_LEVEL_COM_FARM2POT}
     org.springframework: ${LOGGING_LEVEL_ORG_SPRINGFRAMEWORK}
     org.springframework.boot.web.embedded.netty: DEBUG
+
+common:
+  response:
+    wrap:
+      enabled: false
+


### PR DESCRIPTION
 ### 1. Gateway 설정
```yaml
  common:
    response:
      wrap:
        enabled: false  # Gateway에서는 응답 처리 안함
```

### 2. common/build.gradle - 의존성 최적화
```yaml
  dependencies {
      api 'org.springframework.boot:spring-boot-starter'

      // 변경: implementation → compileOnly
      compileOnly 'org.springframework.boot:spring-boot-starter-web'

      api "org.mapstruct:mapstruct:${mapstructVersion}"
      annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
  }
```
>  - Gateway(WebFlux): MVC 의존성이 런타임에 포함X → 충돌 없음
> - Admin/User/Subscription(MVC): 자체적으로 spring-boot-starter-web을 가지고 있어서 정상 작동

### 3. GatewayErrorCode 수정
- 변경 전: private final HttpStatus status;
- 변경 후: private final HttpStatus httpStatus;

  ---
### 참고
**아키텍처 동작 방식**

  클라이언트 요청
      ↓
  Gateway (WebFlux) - 라우팅만 수행
      ↓
  Admin/User 서비스 (MVC)
      ↓
  Controller → DTO 반환
      ↓
  ApiResponseBodyAdvice → ApiResponse로 래핑
      ↓
  Gateway → 그대로 전달 (변환 안함)
      ↓
  클라이언트에게 ApiResponse 응답